### PR TITLE
Very minor fixes required to support current FF Nightly (48)

### DIFF
--- a/webpush/encrypt.go
+++ b/webpush/encrypt.go
@@ -52,6 +52,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -110,12 +111,16 @@ func SubscriptionFromJSON(b []byte) (*Subscription, error) {
 	}
 	json.Unmarshal(b, &sub)
 
-	key, err := base64.URLEncoding.DecodeString(sub.Keys.P256dh)
+	b64 := base64.URLEncoding.WithPadding(base64.NoPadding)
+
+	// Chrome < 52 incorrectly adds padding when Base64 encoding the values, so
+	// we need to strip that out
+	key, err := b64.DecodeString(strings.TrimRight(sub.Keys.P256dh, "="))
 	if err != nil {
 		return nil, err
 	}
 
-	auth, err := base64.URLEncoding.DecodeString(sub.Keys.Auth)
+	auth, err := b64.DecodeString(strings.TrimRight(sub.Keys.Auth, "="))
 	if err != nil {
 		return nil, err
 	}

--- a/webpush/encrypt_test.go
+++ b/webpush/encrypt_test.go
@@ -27,7 +27,7 @@ var (
 	// message using the mock salt and keys and the fake subscription.
 	expectedCiphertextHex = "c29da35b8ad084b3cda4b3c20bd9d1bb9098dfb5c8e7c2e3a67fe7c91ff887b72f"
 	// A fake subscription created with random key and auth values
-	subscriptionJSON      = []byte(`{
+	subscriptionJSON = []byte(`{
 		"endpoint": "https://example.com/",
 		"keys": {
 			"p256dh": "BCXJI0VW7evda9ldlo18MuHhgQVxWbd0dGmUfpQedaD7KDjB8sGWX5iiP7lkjxi-A02b8Fi3BMWWLoo3b4Tdl-c=",

--- a/webpush/encrypt_test.go
+++ b/webpush/encrypt_test.go
@@ -58,6 +58,49 @@ func stubFuncs(salt func() ([]byte, error), key func() ([]byte, []byte, error)) 
 	}
 }
 
+func TestSubscriptionFromJSON(t *testing.T) {
+	_, err := SubscriptionFromJSON(subscriptionJSON)
+	if err != nil {
+		t.Errorf("Failed to parse main sample subscription: %v", err)
+	}
+
+	// key and auth values are valid Base64 with or without padding
+	_, err = SubscriptionFromJSON([]byte(`{
+		"endpoint": "https://example.com",
+		"keys": {
+			"p256dh": "AAAA",
+			"auth": "AAAA"
+		}
+	}`))
+	if err != nil {
+		t.Errorf("Failed to parse subscription with 4-character values: %v", err)
+	}
+
+	// key and auth values are padded Base64
+	_, err = SubscriptionFromJSON([]byte(`{
+		"endpoint": "https://example.com",
+		"keys": {
+			"p256dh": "AA==",
+			"auth": "AAA="
+		}
+	}`))
+	if err != nil {
+		t.Errorf("Failed to parse subscription with padded values: %v", err)
+	}
+
+	// key and auth values are unpadded Base64
+	_, err = SubscriptionFromJSON([]byte(`{
+		"endpoint": "https://example.com",
+		"keys": {
+			"p256dh": "AA",
+			"auth": "AAA"
+		}
+	}`))
+	if err != nil {
+		t.Errorf("Failed to parse subscription with unpadded values: %v", err)
+	}
+}
+
 func TestEncrypt(t *testing.T) {
 	sub, err := SubscriptionFromJSON(subscriptionJSON)
 	if err != nil {


### PR DESCRIPTION
R: @crhym3 @gauntface 

@crhym3 I found a more elegant solution in the end

I successfully sent a push with payload to FF for the first time today. FF has the correct behaviour according to the spec.

A fix to the bug in Chrome is out for review but won't land until 51 at least, probably 52 because the branch point has already gone.
