### PR TITLE
Vapid support

### DIFF
--- a/webpush/encrypt.go
+++ b/webpush/encrypt.go
@@ -130,6 +130,9 @@ func SubscriptionFromJSON(b []byte) (*Subscription, error) {
 	return &Subscription{sub.Endpoint, key, auth}, nil
 }
 
+// TODO: rename ServerPublicKey to 'dhKey' or 'tmpKey' - to avoid confusion
+// with the VAPID ServerPublicKey
+
 // EncryptionResult stores the result of encrypting a message. The ciphertext is
 // the actual encrypted message, while the salt and server public key are
 // required to be sent to the client so that the message can be decrypted.
@@ -138,6 +141,25 @@ type EncryptionResult struct {
 	Salt            []byte
 	ServerPublicKey []byte
 }
+
+// Decrypt an encrypted messages.
+func Decrypt(sub *Subscription, crypt *EncryptionResult, subPrivate []byte) (plain []byte, err error) {
+	secret := sharedSecret(curve, crypt.ServerPublicKey, subPrivate)
+	prk := hkdf(sub.Auth, secret, authInfo, 32)
+
+	// Derive the Content Encryption Key and nonce
+	ctx := newContext(sub.Key, crypt.ServerPublicKey)
+	cek := newCEK(ctx, crypt.Salt, prk)
+	nonce := newNonce(ctx, crypt.Salt, prk)
+
+	plain, err = decrypt(crypt.Ciphertext, cek, nonce)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// TODO: input should be a []byte ( proto, etc )
 
 // Encrypt a message such that it can be sent using the Web Push protocol.
 // You can find out more about the various pieces:
@@ -291,7 +313,28 @@ func encrypt(plaintext, key, nonce []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	// TODO: to reduce allocations, allow out buffer to be passed in
+	// (all temp buffers can be kept in a context, size is bound)
 	return gcm.Seal([]byte{}, nonce, data, nil), nil
+}
+
+// Decrypt the message using AES128/GCM
+func decrypt(ciphertext, key, nonce []byte) (plaintext []byte, err error) {
+	c, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(c)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err = gcm.Open([]byte{}, nonce, ciphertext, nil)
+	if err == nil && len(plaintext) >= 2 {
+		// TODO: read the first 2 bytes, skip that many bytes padding
+		plaintext = plaintext[2:]
+	}
+	return
 }
 
 // Given the coordinates of a party A's public key and the bytes of party B's

--- a/webpush/encrypt_test.go
+++ b/webpush/encrypt_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"strings"
 	"testing"
+	"encoding/base64"
 )
 
 var (
@@ -98,6 +99,31 @@ func TestSubscriptionFromJSON(t *testing.T) {
 	}`))
 	if err != nil {
 		t.Errorf("Failed to parse subscription with unpadded values: %v", err)
+	}
+}
+
+func Test2Way(t *testing.T) {
+	b64 := base64.URLEncoding.WithPadding(base64.NoPadding)
+
+	subPriv, subPub, err := randomKey()
+	auth, err := b64.DecodeString("68zcbmaevQa7MS7aXXRX8Q")
+	sub := &Subscription{
+		Endpoint: "https://foo.com",
+		Auth: auth,
+		Key: subPub,
+	}
+	result, err := Encrypt(sub, message)
+	if err != nil {
+		t.Error(err)
+	}
+
+	plain, err := Decrypt(sub, result, subPriv)
+
+	// assumes 2-bytes padding length == 0
+
+	if string(plain) != message {
+		t.Error(plain, message)
+		return
 	}
 }
 

--- a/webpush/realpush_test.go
+++ b/webpush/realpush_test.go
@@ -1,0 +1,44 @@
+package webpush
+
+import (
+	"testing"
+	"net/http/httputil"
+	"encoding/hex"
+	"net/http"
+)
+
+var (
+	// From peter.sh sample
+        vapidPub = []byte("048623C185F06C5D551AD919AAE9022F4355D25C59866990ADF72DD422D863B6CDEF33B1BB662F47E5E620FF0E107FCDA34F8C65F4647E2CF36BF87C4B0CBDBFFE")
+        vapidPriv = []byte("3C8F4B1E164169C80F3F1C60E5EA3CDD72CCE6056B0240EEDF7B1D5CA8529181")
+
+)
+func TestChrome(t *testing.T) {
+	// Send to a real chrome subscription.
+	ep := []byte(`{"endpoint":"https://jmt17.google.com/gcm/demo-webpush-00/eRUec0FiUOA:APA91bFyWIKZz5QAusYHrIXwINgssqQ-pz9dG4pzOYUoOEvqmbjVicNj8beZUfZUT3rWrbYC3-khWp4hyOGJbj9_4hfAN5dSj5PHrQ7i5fUGiqgt04upfsQP_ACAZLJGs5qnIudrBcyo","keys":{"p256dh":"BJIzHZoGcIay4RAnAvz5mo0s-zu6na9fJKKCmt1ekBOXHxfOVF05bv2AeKaz6b8XMd4n5QpnWJAnHPjaTJKlJcU","auth":"68zcbmaevQa7MS7aXXRX8Q"}}`)
+
+	sub, err := SubscriptionFromJSON(ep)
+	if err != nil {
+		t.Error(err)
+	}
+
+	message := "I am the walrus"
+
+	vpub := make([]byte, len(vapidPub) / 2)
+	vpriv := make([]byte, len(vapidPriv) / 2)
+	hex.Decode(vpub, vapidPub)
+	hex.Decode(vpriv, vapidPriv)
+
+	vapid := NewVapid(vpub, vpriv)
+	req, err := NewVapidRequest(sub, message, vapid)
+	dmpReq, err := httputil.DumpRequest(req, true)
+	t.Log(string(dmpReq))
+	res, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		t.Error(err)
+	}
+	dmp, err := httputil.DumpResponse(res, true)
+	t.Log(string(dmp))
+
+}

--- a/webpush/vapid.go
+++ b/webpush/vapid.go
@@ -1,0 +1,117 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webpush
+
+import (
+	"crypto/elliptic"
+	"math/big"
+	"crypto/ecdsa"
+	"crypto"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+)
+
+
+var (
+	//curve = elliptic.P256()
+	vapid_prefix = []byte("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.")
+	dot = []byte(".")
+)
+
+type jwtPrefix struct {
+
+}
+
+type jwtBody struct {
+	Aud string `json:"aud"`
+	Sub string `json:"sub"`
+	Exp int64 `json:"exp"`
+}
+
+// Vapid represents a sender identity.
+type Vapid struct {
+	// The EC256 public key. This value should be used in 'subscribe' requests
+	// and is included a p256ecdsa in the Crypto-Key header.
+	PublicKey []byte
+
+	// The private key used to sign tokens
+	pkey *ecdsa.PrivateKey
+}
+
+// Create a token with the specified audience, subject and expiry
+func (vapid *Vapid) Token(aud, sub string, exp int64) (res string, err error) {
+	t, _ := json.Marshal(
+		jwtBody{Aud: aud,
+			Sub: sub,
+			Exp: exp})
+	enc := base64.RawURLEncoding
+
+	t64 := make([]byte, enc.EncodedLen(len(t)))
+	enc.Encode(t64, t)
+
+	token := make([]byte, len(t) + len(vapid_prefix) + 100)
+	token = append(token[:0], vapid_prefix...)
+	token = append(token, t64...)
+
+	hasher := crypto.SHA256.New()
+	hasher.Write(token)
+
+	if r, s, err := ecdsa.Sign(rand.Reader, vapid.pkey, hasher.Sum(nil)); err == nil {
+		// Vapid key is 32 bytes
+		keyBytes := 32
+		sig := make([]byte, 2 *keyBytes)
+
+		rBytes := r.Bytes()
+		rBytesPadded := make([]byte, keyBytes)
+		copy(rBytesPadded[keyBytes - len(rBytes):], rBytes)
+
+		sBytes := s.Bytes()
+		sBytesPadded := make([]byte, keyBytes)
+		copy(sBytesPadded[keyBytes - len(sBytes):], sBytes)
+
+		sig = append(sig[:0], rBytesPadded...)
+		sig = append(sig, sBytesPadded...)
+
+		sigB64 := make([]byte, enc.EncodedLen(len(sig)))
+		enc.Encode(sigB64, sig)
+
+
+		token = append(token, dot...)
+		token = append(token, sigB64...)
+	}
+	res = string(token)
+	return
+}
+
+
+// NewVapid constructs a new Vapid generator from EC256 public and private keys,
+// in uncompressed format
+func NewVapid(publicUncomp, privateUncom []byte) (v *Vapid){
+	// Public key is a point, starting with 0x4
+	x, y := elliptic.Unmarshal(curve, publicUncomp)
+	d := new(big.Int).SetBytes(privateUncom)
+	pubkey := ecdsa.PublicKey{curve, x, y}
+	pkey := ecdsa.PrivateKey{pubkey, d}
+	enc := base64.RawURLEncoding
+	pub64 := make([]byte, enc.EncodedLen(len(publicUncomp)))
+	enc.Encode(pub64, publicUncomp)
+
+	v = &Vapid{
+		PublicKey: pub64,
+		pkey: &pkey}
+
+	return
+}


### PR DESCRIPTION
Support for Vapid authentication. 

The e2e testing needs more work - right now it hits a specific subscription, will be accepted but 
there is no way to verify delivery. 
